### PR TITLE
Backlink insertion is idempotent

### DIFF
--- a/lib/updateBacklinks.ts
+++ b/lib/updateBacklinks.ts
@@ -82,13 +82,23 @@ export default function updateBacklinks(
             )
             .join("")}`
       )
-      .join("")}\n`;
+      .join("")}`.trim();
   }
 
-  const newNoteContents =
-    noteContents.slice(0, insertionOffset) +
-    backlinksString +
-    noteContents.slice(oldEndOffset);
+  let newNoteContents = noteContents;
+
+  if (backlinksString) {
+    let end = noteContents.slice(oldEndOffset).trim()
+
+    if (end) {
+      end = `\n${end}\n`;
+    }
+
+    newNoteContents =
+      noteContents.slice(0, insertionOffset).trimEnd() + "\n\n" +
+      backlinksString + "\n" +
+      end
+  }
 
   return newNoteContents;
 }


### PR DESCRIPTION
Prior to this, there was no newline between the text prior to the backlinks which caused it to not properly detect the backlink section.

Mirrors the PR in the original repo.